### PR TITLE
Check length

### DIFF
--- a/load_datx.m
+++ b/load_datx.m
@@ -283,10 +283,14 @@ end
 
 function cleanedData = clean(inputData, value)
     [rows2remove, ~] = find(inputData == value);
-    rows2remove = unique(rows2remove);
-
     cleanedData = inputData;
-
+    
+    % If no rows2remove return (out = in)
+    if isempty(rows2remove)
+        return;
+    end
+    
+    rows2remove = unique(rows2remove);
     for i = 1 : length(rows2remove)
         r = rows2remove(i);
         cleanedData(r, :) = cleanedData(r - 1, :);


### PR DESCRIPTION
Added a check on the length of recording in .dat / .datx files. 

The number of samples is compared to the expected number calculated from the start time, stop time and sample rate in the file header. 

If the difference is > 5 minutes an error is thrown, otherwise:
- If the expected < actual then the excess is removed (assumed to be empty memory (255) or tail data (older files have no clear method to locate tail start)).
- If expected > actual then a warning is given. 

As the 255 values found at the end of the data are often now removed some work was done  to optimise the clean function which handles these values. 
If no invalid values are found then out = in and the function returns, bypassing the cleaning steps. 